### PR TITLE
Scrape cashflow and balance sheet table

### DIFF
--- a/cli
+++ b/cli
@@ -18,6 +18,13 @@ try:
     tickers = fetch(session, args.limit)
     stocks = [scrape(session, ticker) for ticker in tickers]
 
+    if args.print_output:
+        for stock in stocks:
+            debug("\nP&L:")
+            debug(stock.financial_data_raw.to_string())
+            debug("\nCashflow:")
+            debug(stock.cashflow_data_raw.to_string())
+
 except Exception as err:
     debug("Programme failed.", force=True)
     debug(err)

--- a/cli
+++ b/cli
@@ -24,6 +24,8 @@ try:
             debug(stock.financial_data_raw.to_string())
             debug("\nCashflow:")
             debug(stock.cashflow_data_raw.to_string())
+            debug("\nBalance Sheet:")
+            debug(stock.balance_sheet_data_raw.to_string())
 
 except Exception as err:
     debug("Programme failed.", force=True)

--- a/lib/scraper.py
+++ b/lib/scraper.py
@@ -6,7 +6,7 @@ import pandas as pd
 from bs4 import BeautifulSoup
 from lib.utils.classes import Stock
 from lib.utils.args import debug
-from lib.utils.row_names import profit_loss_row_names, cashflow_row_names
+from lib.utils.row_names import profit_loss_row_names, cashflow_row_names, balance_sheet_row_names
 from bs4 import BeautifulSoup, Tag
 
 # Given a ticker, scrapes the web for information and returns a Stock object
@@ -23,10 +23,14 @@ def scrape(session: requests.Session, ticker: str) -> Stock:
     cashflow_data_raw_df = parse_table(
         soup.select_one('#cash-flow .data-table'),
         cashflow_row_names)
+    balance_sheet_data_raw_df = parse_table(
+        soup.select_one('#balance-sheet .data-table'),
+        balance_sheet_row_names)
 
     stock = Stock(ticker, name, url)
     stock.set_financial_data_raw(financial_data_raw_df)
     stock.set_cashflow_data_raw(cashflow_data_raw_df)
+    stock.set_balance_sheet_data_raw(balance_sheet_data_raw_df)
     return stock
 
 def parse_table(ref: Tag, row_names: Dict[str, str]) -> pd.DataFrame:

--- a/lib/scraper.py
+++ b/lib/scraper.py
@@ -6,7 +6,7 @@ import pandas as pd
 from bs4 import BeautifulSoup
 from lib.utils.classes import Stock
 from lib.utils.args import debug
-from lib.utils.row_names import profit_loss_row_names
+from lib.utils.row_names import profit_loss_row_names, cashflow_row_names
 from bs4 import BeautifulSoup, Tag
 
 # Given a ticker, scrapes the web for information and returns a Stock object
@@ -20,9 +20,13 @@ def scrape(session: requests.Session, ticker: str) -> Stock:
     financial_data_raw_df = parse_table(
         soup.select_one('#profit-loss .data-table'),
         profit_loss_row_names)
+    cashflow_data_raw_df = parse_table(
+        soup.select_one('#cash-flow .data-table'),
+        cashflow_row_names)
 
     stock = Stock(ticker, name, url)
     stock.set_financial_data_raw(financial_data_raw_df)
+    stock.set_cashflow_data_raw(cashflow_data_raw_df)
     return stock
 
 def parse_table(ref: Tag, row_names: Dict[str, str]) -> pd.DataFrame:

--- a/lib/utils/args.py
+++ b/lib/utils/args.py
@@ -18,8 +18,18 @@ parser.add_argument(
     dest="debug"
 )
 
+parser.add_argument(
+    "-p, --print-output",
+    type=bool,
+    help="Print the scraped data in a tabular format",
+    default=False,
+    dest="print_output"
+)
+
 args = parser.parse_args()
 
 def debug(message: str, force=False):
     if args.debug == True:
-        print("*** ", message)
+        lines = message.split('\n')
+        for line in lines:
+            print("*** ", line)

--- a/lib/utils/classes.py
+++ b/lib/utils/classes.py
@@ -16,6 +16,7 @@ class Stock:
     # rows: net_profit
     # columns: years (or TTM)
     financial_data_raw: pd.DataFrame
+    cashflow_data_raw: pd.DataFrame
 
     def __init__(self, ticker, name, url):
         self.ticker = ticker
@@ -24,4 +25,7 @@ class Stock:
     
     def set_financial_data_raw(self, financial_data_raw):
         self.financial_data_raw = financial_data_raw
+    
+    def set_cashflow_data_raw(self, cashflow_data_raw):
+        self.cashflow_data_raw = cashflow_data_raw
     

--- a/lib/utils/classes.py
+++ b/lib/utils/classes.py
@@ -17,6 +17,7 @@ class Stock:
     # columns: years (or TTM)
     financial_data_raw: pd.DataFrame
     cashflow_data_raw: pd.DataFrame
+    balance_sheet_data_raw: pd.DataFrame
 
     def __init__(self, ticker, name, url):
         self.ticker = ticker
@@ -28,4 +29,7 @@ class Stock:
     
     def set_cashflow_data_raw(self, cashflow_data_raw):
         self.cashflow_data_raw = cashflow_data_raw
+    
+    def set_balance_sheet_data_raw(self, balance_sheet_data_raw):
+        self.balance_sheet_data_raw = balance_sheet_data_raw
     

--- a/lib/utils/row_names.py
+++ b/lib/utils/row_names.py
@@ -12,3 +12,10 @@ profit_loss_row_names = {
     "eps in rs": "eps",
     "dividend payout": "dpr",
 }
+
+cashflow_row_names = {
+    "cash from operating activity": "cfo_operating",
+    "cash from investing activity": "cfo_investing",
+    "cash from financing activity": "cfo_financing",
+    "net cash flow": "cfo_net",
+}

--- a/lib/utils/row_names.py
+++ b/lib/utils/row_names.py
@@ -19,3 +19,13 @@ cashflow_row_names = {
     "cash from financing activity": "cfo_financing",
     "net cash flow": "cfo_net",
 }
+
+balance_sheet_row_names = {
+    "share capital": "equity",
+    "reserves": "reserves",
+    "borrowings": "borrowings",
+    "total liabilities": "total_liabilities",
+    "fixed assets": "fixed_assets",
+    "cwip": "cwip",
+    "total assets": "total_assets",
+}


### PR DESCRIPTION
Scrape cashflow table, balance sheet table too!

Also added another param "-p" or "--print-output" which prints scraped data as a table

```
ccpandhare@ccpandhare-mbp stock-analyser % ./cli -l 1 -p 1
***  Using LIMIT 1
***  Scraping RELIANCE
***  
***  P&L:
***                      2011    2012    2013    2014    2015    2016    2017    2018    2019    2020    2021    2022
***  revenue           265050  357677  395957  433521  374372  272583  303954  390823  568337  596679  466307  699962
***  operating_profit   38623   33176   33155   34935   37449   41781   46307   64315   84250   89266   80790  110460
***  opm                  15%      9%      8%      8%     10%     15%     15%     16%     15%     15%     17%     16%
***  interest            2411    2893    3463    3836    3316    3691    3849    8052   16495   22027   21189   14584
***  depreciation       14121   12401   11232   11201   11547   11565   11646   16706   20934   22203   26572   29797
***  pbt                24055   25408   26217   28763   31114   38737   40034   49426   55227   53606   55461   84142
***  net_profit         19294   19724   20879   22493   23566   29745   29901   36075   39588   39354   49128   60705
***  eps                27.63   28.27   30.31   32.62   34.14   43.03   43.11   53.39   58.55   58.20   77.50   89.74
***  dpr                  12%     13%     13%     12%     12%     10%     11%     10%     10%     10%      9%      9%
***  
***  Cashflow:
***                  2011   2012   2013   2014   2015   2016   2017   2018   2019   2020    2021    2022
***  cfo_operating  33338  24483  36918  43261  34374  38134  49550  71459  42346  94877   26185  110654
***  cfo_investing -32040  -6301 -27601 -73070 -64706 -36186 -66201 -68192 -94507 -72497 -141610 -110103
***  cfo_financing  14950  -7590    408  13713   8444  -3210   8617  -2001  55906  -2541  101902   17289
***  cfo_net        16248  10592   9725 -16096 -21888  -1262  -8034   1266   3745  19839  -13523   17840
***  
***  Balance Sheet:
***                       2011    2012    2013    2014    2015    2016    2017    2018    2019     2020     2021     2022
***  equity               2981    2979    2936    2940    2943    2948    2959    5922    5926     6339     6445     6765
***  reserves           151112  166466  179094  195730  215539  228600  260746  287569  381184   442826   653884   772720
***  borrowings          84152   92447  107219  138761  168251  194714  217475  239843  307714   355133   270648   281974
***  total_liabilities  307519  327191  362357  428843  504486  598997  706802  811273  997630  1163015  1320065  1499665
***  fixed_assets       158100  138814  133487  141417  156458  184910  198526  403885  398374   532658   541258   732252
***  cwip                28174   25363   49952   91494  166462  228697  324837  187022  179463   109106   125953    68052
***  total_assets       307519  327191  362357  428843  504486  598997  706802  811273  997630  1163015  1320065  1499665
```